### PR TITLE
Update 001-test-expansions.phpt

### DIFF
--- a/tests/001-test-expansions.phpt
+++ b/tests/001-test-expansions.phpt
@@ -22,9 +22,7 @@ foreach ($expansions as $expansion) {
 --EXPECT--
 92 avenue des champs-elysees
 92 avenue des champs elysees
-92 avenue des champselysees
 92 avenue des champs-elysees
 92 avenue des champs elysees
-92 avenue des champselysees
 friedrichstrasse 128 berlin germany
 friedrich strasse 128 berlin germany


### PR DESCRIPTION
Fix #14 

`92 avenue des champselysees` is "wrong": `champs` and `elysees` are 2 words.