### PR TITLE
Define ulong when building for macOS 10.15.x (Catalina)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ config.nice
 config.status
 config.sub
 configure
+configure.ac
 configure.in
 include
 install-sh

--- a/php_postal.h
+++ b/php_postal.h
@@ -21,6 +21,10 @@
 #ifndef PHP_POSTAL_H
 #define PHP_POSTAL_H
 
+#ifdef __APPLE__
+typedef unsigned long   ulong;
+#endif
+
 extern zend_module_entry postal_module_entry;
 #define phpext_postal_ptr &postal_module_entry
 
@@ -45,9 +49,9 @@ PHP_MINFO_FUNCTION(postal);
 PHP_METHOD(Expand, expand_address);
 PHP_METHOD(Parser, parse_address);
 
-/* 
+/*
   	Declare any global variables you may need between the BEGIN
-	and END macros here:     
+	and END macros here:
 
 ZEND_BEGIN_MODULE_GLOBALS(postal)
 	long  global_value;
@@ -55,12 +59,12 @@ ZEND_BEGIN_MODULE_GLOBALS(postal)
 ZEND_END_MODULE_GLOBALS(postal)
 */
 
-/* In every utility function you add that needs to use variables 
-   in php_postal_globals, call TSRMLS_FETCH(); after declaring other 
+/* In every utility function you add that needs to use variables
+   in php_postal_globals, call TSRMLS_FETCH(); after declaring other
    variables used by that function, or better yet, pass in TSRMLS_CC
    after the last function argument and declare your utility function
    with TSRMLS_DC after the last declared argument.  Always refer to
-   the globals in your function as POSTAL_G(variable).  You are 
+   the globals in your function as POSTAL_G(variable).  You are
    encouraged to rename these macros something shorter, see
    examples in any other php module directory.
 */


### PR DESCRIPTION
Resolves `use of undeclared identifier 'ulong'` messages when building on macOS Catalina (see also #21 )