### PR TITLE
Windows support (incl. AppVeyor CI builds)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,84 @@
+# general configuration
+version: '{branch}.{build}'
+
+# environment configuration
+image: Visual Studio 2017
+clone_folder: c:\projects\php-postal
+environment:
+  BIN_SDK_VER: 2.2.0
+  matrix:
+    - PHP_VER: 7.4.6
+      LIBPOSTAL_BUILD: q6a58sbt9ynsmafx
+      ARCH: x64
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.4.6
+      LIBPOSTAL_BUILD: q6a58sbt9ynsmafx
+      ARCH: x64
+      TS: 1
+      VC: vc15
+    - PHP_VER: 7.4.6
+      LIBPOSTAL_BUILD: pdyd7jcbohebmshu
+      ARCH: x86
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.4.6
+      LIBPOSTAL_BUILD: pdyd7jcbohebmshu
+      ARCH: x86
+      TS: 1
+      VC: vc15
+    - PHP_VER: 7.3.18
+      LIBPOSTAL_BUILD: q6a58sbt9ynsmafx
+      ARCH: x64
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.3.18
+      LIBPOSTAL_BUILD: q6a58sbt9ynsmafx
+      ARCH: x64
+      TS: 1
+      VC: vc15
+    - PHP_VER: 7.3.18
+      LIBPOSTAL_BUILD: pdyd7jcbohebmshu
+      ARCH: x86
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.3.18
+      LIBPOSTAL_BUILD: pdyd7jcbohebmshu
+      ARCH: x86
+      TS: 1
+      VC: vc15
+    - PHP_VER: 7.2.31
+      LIBPOSTAL_BUILD: q6a58sbt9ynsmafx
+      ARCH: x64
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.2.31
+      LIBPOSTAL_BUILD: q6a58sbt9ynsmafx
+      ARCH: x64
+      TS: 1
+      VC: vc15
+    - PHP_VER: 7.2.31
+      LIBPOSTAL_BUILD: pdyd7jcbohebmshu
+      ARCH: x86
+      TS: 0
+      VC: vc15
+    - PHP_VER: 7.2.31
+      LIBPOSTAL_BUILD: pdyd7jcbohebmshu
+      ARCH: x86
+      TS: 1
+      VC: vc15
+cache:
+  - c:\build-cache -> .appveyor.yml, .appveyor\install.ps1
+install:
+  - ps: .appveyor\install.ps1
+
+# build configuration
+build_script:
+  - ps: .appveyor\build.ps1
+
+after_build:
+  - ps: .appveyor\package.ps1
+
+# artifacts configuration
+artifacts:
+  - path: php-postal.zip

--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location C:\projects\php-postal
+
+$task = New-Item 'task.bat' -Force
+Add-Content $task 'call phpize 2>&1'
+Add-Content $task 'call configure --with-php-build=C:\build-cache\deps --enable-postal --enable-debug-pack 2>&1'
+Add-Content $task 'nmake /nologo 2>&1'
+Add-Content $task 'exit %errorlevel%'
+& "C:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task
+if (-not $?) {
+    throw "building failed with errorlevel $LastExitCode"
+}

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,0 +1,70 @@
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path 'C:\build-cache')) {
+    [void](New-Item 'C:\build-cache' -ItemType 'directory')
+}
+
+# PHP SDK
+$bname = "php-sdk-$env:BIN_SDK_VER.zip"
+if (-not (Test-Path C:\build-cache\$bname)) {
+    Invoke-WebRequest "https://github.com/microsoft/php-sdk-binary-tools/archive/$bname" -OutFile "C:\build-cache\$bname"
+}
+$dname0 = "php-sdk-binary-tools-php-sdk-$env:BIN_SDK_VER"
+$dname1 = "php-sdk-$env:BIN_SDK_VER"
+if (-not (Test-Path "C:\build-cache\$dname1")) {
+    Expand-Archive "C:\build-cache\$bname" "C:\build-cache"
+    Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
+}
+
+# PHP devel pack
+$ts_part = ''
+if ('0' -eq $env:TS) {
+    $ts_part = '-nts'
+}
+$bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    try {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    } catch [System.Net.WebException] {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    }
+}
+$dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
+if (-not (Test-Path "C:\build-cache\$dname1")) {
+    Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
+    if ($dname0 -ne $dname1) {
+        Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
+    }
+}
+$env:PATH = "C:\build-cache\$dname1;$env:PATH"
+
+# PHP binary
+$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    try {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    } catch [System.Net.WebException] {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    }
+}
+$dname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH"
+if (-not (Test-Path "C:\build-cache\$dname")) {
+    Expand-Archive "C:\build-cache\$bname" "C:\build-cache\$dname"
+}
+$env:PHP_PATH = "C:\build-cache\$dname"
+$env:PATH = "$env:PHP_PATH;$env:PATH"
+
+# library dependency
+$bname = "libpostal.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    Invoke-WebRequest "https://ci.appveyor.com/api/buildjobs/$env:LIBPOSTAL_BUILD/artifacts/$bname" -OutFile "C:\build-cache\$bname"
+    Expand-Archive "C:\build-cache\$bname" 'C:\build-cache\deps'
+    [void](New-Item "C:\build-cache\deps\bin" -ItemType 'directory')
+    Move-Item 'C:\build-cache\deps\libpostal.dll' 'C:\build-cache\deps\bin\libpostal.dll'
+    [void](New-Item "C:\build-cache\deps\include\libpostal" -ItemType 'directory')
+    Move-Item 'C:\build-cache\deps\libpostal.h' 'C:\build-cache\deps\include\libpostal\libpostal.h'
+    [void](New-Item "C:\build-cache\deps\lib" -ItemType 'directory')
+    Move-Item 'C:\build-cache\deps\libpostal.lib' 'C:\build-cache\deps\lib\libpostal.lib'
+}
+$env:PATH = "C:\build-cache\deps\bin;$env:PATH"

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location C:\projects\php-postal
+
+$dname = ''
+if ($env:ARCH -eq 'x64') {
+    $dname += 'x64\'
+}
+$dname += 'Release';
+if ($env:TS -eq '1') {
+    $dname += '_TS'
+}
+
+$files = 
+    'C:\projects\php-postal\README.md',
+    'C:\projects\php-postal\LICENSE',
+    'C:\build-cache\deps\bin\libpostal.dll',
+    "$dname\php_postal.dll"
+
+Compress-Archive $files 'php-postal.zip' -CompressionLevel 'Optimal'

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,10 @@
+ARG_ENABLE("postal", "postal support", "no");
+
+if (PHP_POSTAL != "no") {
+	if (CHECK_LIB("libpostal.lib", "postal", PHP_POSTAL) &&
+		CHECK_HEADER_ADD_INCLUDE("libpostal/libpostal.h", "CFLAGS_POSTAL")) {
+		EXTENSION("postal", "php_postal.c");
+	} else {
+		WARNING("postal not enabled; libraries and/or headers not found");
+	}
+}

--- a/php_postal.c
+++ b/php_postal.c
@@ -231,7 +231,7 @@ PHP_METHOD(Expand, expand_address) {
                 if (lang_len > LIBPOSTAL_MAX_LANGUAGE_LEN) {
                     continue;
                 }
-                char *lang = strndup(Z_STRVAL_PP(php_lang), lang_len);
+                char *lang = zend_strndup(Z_STRVAL_PP(php_lang), lang_len);
 
                 languages[num_languages++] = lang;
 
@@ -252,7 +252,7 @@ PHP_METHOD(Expand, expand_address) {
             size_t num_php_langs = zend_hash_num_elements(Z_ARRVAL_P(val));
             languages = malloc(sizeof(char *) * num_php_langs);
 
-            ulong num_key;
+            unsigned long num_key;
             zend_string *key;
             zval *php_lang;
 
@@ -266,7 +266,7 @@ PHP_METHOD(Expand, expand_address) {
                 if (lang_len > LIBPOSTAL_MAX_LANGUAGE_LEN) {
                     continue;
                 }
-                char *lang = strndup(Z_STRVAL_P(php_lang), lang_len);
+                char *lang = zend_strndup(Z_STRVAL_P(php_lang), lang_len);
 
                 languages[num_languages++] = lang;
 
@@ -600,13 +600,13 @@ PHP_METHOD(Parser, parse_address) {
 
 #if PHP_MAJOR_VERSION == 5
         if (zend_hash_find(php_options, LANGUAGE_KEY, strlen(LANGUAGE_KEY) + 1, (void **)&val) == SUCCESS && Z_TYPE_PP(val) == IS_STRING) {
-            language = strndup(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+            language = zend_strndup(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
             options.language = language;
         }
 #elif PHP_MAJOR_VERSION == 7
         str = zend_string_init(LANGUAGE_KEY, strlen(LANGUAGE_KEY), 0);
         if ((val = zend_hash_find(php_options, str)) && Z_TYPE_P(val) == IS_STRING) {
-            language = strndup(Z_STRVAL_P(val), Z_STRLEN_P(val));
+            language = zend_strndup(Z_STRVAL_P(val), Z_STRLEN_P(val));
             options.language = language;
         }
 #endif
@@ -615,12 +615,12 @@ PHP_METHOD(Parser, parse_address) {
 
 #if PHP_MAJOR_VERSION == 5
         if (zend_hash_find(php_options, COUNTRY_KEY, strlen(COUNTRY_KEY) + 1, (void **)&val) == SUCCESS && Z_TYPE_PP(val) == IS_STRING) {
-            country = strndup(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
+            country = zend_strndup(Z_STRVAL_PP(val), Z_STRLEN_PP(val));
         }
 #elif PHP_MAJOR_VERSION == 7
         str = zend_string_init(COUNTRY_KEY, strlen(COUNTRY_KEY), 0);
         if ((val = zend_hash_find(php_options, str)) && Z_TYPE_P(val) == IS_STRING) {
-            country = strndup(Z_STRVAL_P(val), Z_STRLEN_P(val));
+            country = zend_strndup(Z_STRVAL_P(val), Z_STRLEN_P(val));
             options.country = country;
         }
 #endif


### PR DESCRIPTION
There seems to be interest in being able to use php-postal on Windows (#16); these patches add basic Windows support, and the AppVeyor CI integration shows how that can be accomplished (plus it creates PECL like binary packages as artifacts).

I think a lot could be improved here; particularly, the hard coded URL of the libpostal binary package, which points to the AppVeyor artifacts of the *currently* latest commit, is obviously suboptimal.

Furthermore, it would be nice to know how to get the libpostal data for users (and also for AppVeyor CI to be able to run the test suite). @c33s's [solution](https://github.com/openvenues/php-postal/issues/16#issuecomment-639894658) worked for me (thanks!), but I'd prefer a Windows only solution.